### PR TITLE
We should use snprintf instead of sprintf

### DIFF
--- a/log4c.c
+++ b/log4c.c
@@ -8,8 +8,12 @@ void log4c(const char* msg, ...) {
     char buffer[1024];
     va_list formatargs;
     va_start(formatargs, msg);
-    vsprintf(buffer, msg, formatargs);
+
+    // FIXME: need to work out the size of the format string
+    int message_length = vsprintf(buffer, msg, formatargs);
+
     char command[1024];
-    sprintf(command, "logger -p user.notice \"%s\"", buffer);
+    int command_length = message_length + 25; // length of the logger command
+    snprintf(command, command_length, "logger -p user.notice \"%s\"", buffer);
     system(command);
 }


### PR DESCRIPTION
I need to work out the length of the message itself,
for now we'll simply fix the command creation.